### PR TITLE
in reindex with create add skipType parameter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,6 +44,13 @@ you should see 'loaded [reindex], sites []' in the logs. Or use the reinstall.sh
 This refeeds all documents in index 'indexold' with type 'typeold' into the index 'indexnew' with type 'typenew'.
 But only documents matching the specified filter will be refeeded. The internal Java API will be used which should be efficient.
 
+## Same cluster with create index api
+> curl -XPUT 'http://localhost:9200/_reindex?index=indexnew&type=*&searchIndex=indexold'
+
+This command creates the indexnew if not exist (the newIndexShards can be set to specify the number of shards).
+If type=* reindex all types from the index. If you want to skip some type and skipType=type1,type2
+
+
 ## Different cluster 
 
 Now JSONObjects and the HttpClient will be used. TODO that is probably not efficient in terms of RAM/CPU?!:

--- a/pom.xml
+++ b/pom.xml
@@ -4,16 +4,16 @@
 
     <groupId>com.pannous.es</groupId>
     <artifactId>reindex</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.4.1</version>
     <packaging>jar</packaging>
 
     <name>Reindex Plugin</name>
     <url>http://maven.apache.org</url>
 
     <properties>
-        <maven.compiler.target>1.6</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <elasticsearch.version>1.4.0</elasticsearch.version>
+	<maven.compiler.target>1.6</maven.compiler.target>
+	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	<elasticsearch.version>1.4.0</elasticsearch.version>
     </properties>
 
     <dependencies>
@@ -67,7 +67,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.3</version>
                 <configuration>
-                    <finalName>elasticsearch-${project.artifactId}-${elasticsearch.version}</finalName>
+		    <finalName>elasticsearch-${project.artifactId}-${project.version}</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                     <outputDirectory>${project.build.directory}/</outputDirectory>
                     <descriptors>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <maven.compiler.target>1.6</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <elasticsearch.version>1.3.2</elasticsearch.version>
+        <elasticsearch.version>1.4.0</elasticsearch.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <maven.compiler.target>1.6</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <elasticsearch.version>1.4.0</elasticsearch.version>
+        <elasticsearch.version>1.3.2</elasticsearch.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/pannous/es/reindex/ReIndexAction.java
+++ b/src/main/java/com/pannous/es/reindex/ReIndexAction.java
@@ -30,7 +30,7 @@ import static org.elasticsearch.rest.RestStatus.*;
 public class ReIndexAction extends BaseRestHandler {
 
     @Inject public ReIndexAction(Settings settings, Client client, RestController controller) {
-        super(settings, controller, client);
+        super(settings, client);
 
         if (controller != null) {
             // Define REST endpoints to do a reindex

--- a/src/main/java/com/pannous/es/reindex/ReIndexAction.java
+++ b/src/main/java/com/pannous/es/reindex/ReIndexAction.java
@@ -30,7 +30,7 @@ import static org.elasticsearch.rest.RestStatus.*;
 public class ReIndexAction extends BaseRestHandler {
 
     @Inject public ReIndexAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+        super(settings, controller, client);
 
         if (controller != null) {
             // Define REST endpoints to do a reindex

--- a/src/main/java/com/pannous/es/reindex/ReIndexWithCreate.java
+++ b/src/main/java/com/pannous/es/reindex/ReIndexWithCreate.java
@@ -31,7 +31,7 @@ public class ReIndexWithCreate extends BaseRestHandler {
     private ReIndexAction reindexAction;
 
     @Inject public ReIndexWithCreate(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+        super(settings, controller, client);
 
         // Define REST endpoints to do a reindex
         controller.registerHandler(PUT, "/_reindex", this);

--- a/src/main/java/com/pannous/es/reindex/ReIndexWithCreate.java
+++ b/src/main/java/com/pannous/es/reindex/ReIndexWithCreate.java
@@ -31,7 +31,7 @@ public class ReIndexWithCreate extends BaseRestHandler {
     private ReIndexAction reindexAction;
 
     @Inject public ReIndexWithCreate(Settings settings, Client client, RestController controller) {
-        super(settings, controller, client);
+        super(settings, client);
 
         // Define REST endpoints to do a reindex
         controller.registerHandler(PUT, "/_reindex", this);


### PR DESCRIPTION
Sometime we want to reindex all types include in index except one or two.
You can now add a skipType=type1,type2 to exclude it in reindexation process
  
in case of reindex with create you can add a new field skipType=... in case of type=*

